### PR TITLE
Add tradingview charts from GeckoTerminal for bonded tokens

### DIFF
--- a/packages/client/src/components/chart.tsx
+++ b/packages/client/src/components/chart.tsx
@@ -23,6 +23,25 @@ interface ChartProps {
 }
 
 export default function Chart({ token }: ChartProps) {
+  if (token.status === 'bonded') {
+    return (
+      <div
+        className="w-full min-h-[450px] relative"
+        style={{ width: "100%", height: "100%" }}
+      >
+        <iframe
+          height="100%"
+          width="100%"
+          id="geckoterminal-embed"
+          title="GeckoTerminal Embed"
+          src={`https://www.geckoterminal.com/solana/pools/${token.mint}?embed=1&info=0&swaps=0&grayscale=0&light_chart=0&chart_type=market_cap&resolution=1m`}
+          allow="clipboard-write"
+          allowFullScreen
+        />
+      </div>
+    );
+  }
+
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const candlestickSeriesRef = useRef<any>(null);
   const chartRef = useRef<any>(null);


### PR DESCRIPTION
## Request to add GeckoTerminal iframe charts for bonded tokens only 


### How it works
_Note: Currently GeckoTerminal only tracks bonded tokens from autofun_
1. The pull request checks the token is `bonded`, 
2. if yes, show the iframe. Else, continue the logic to display current lightweight chart 
3. It also ensures that the iframe conforms to the current container logic of the lightweight chart  

_Note: The chart defaults to Market Cap (better for low cap coins) and 1m candlesticks_