### PR TITLE
fix: generation api path

### DIFF
--- a/packages/client/src/pages/create.tsx
+++ b/packages/client/src/pages/create.tsx
@@ -1257,7 +1257,7 @@ export default function Create() {
         headers["Authorization"] = `Bearer ${authToken}`;
       }
 
-      const response = await fetch(env.apiUrl + "/api/generate-metadata", {
+      const response = await fetch(env.apiUrl + "/api/generation/generate-metadata", {
         method: "POST",
         headers,
         credentials: "include",
@@ -1312,7 +1312,7 @@ export default function Create() {
       setIsGenerating(true);
       setGeneratingField("prompt");
 
-      const imageResponse = await fetch(env.apiUrl + "/api/generate", {
+      const imageResponse = await fetch(env.apiUrl + "/api/generation/generate", {
         method: "POST",
         headers,
         credentials: "include",
@@ -1658,7 +1658,7 @@ export default function Create() {
         }
 
         // Get a pre-generated token
-        const response = await fetch(env.apiUrl + "/api/pre-generated-token", {
+        const response = await fetch(env.apiUrl + "/api/generation/pre-generated-token", {
           method: "GET",
           headers,
           credentials: "include",
@@ -1732,7 +1732,7 @@ export default function Create() {
           }
         } else {
           // If no image, generate one using the prompt
-          const imageResponse = await fetch(env.apiUrl + "/api/generate", {
+          const imageResponse = await fetch(env.apiUrl + "/api/generation/generate", {
             method: "POST",
             headers,
             credentials: "include",
@@ -2365,7 +2365,7 @@ export default function Create() {
           }
 
           // Mark the token as used and delete any other tokens with the same name or ticker
-          await fetch(env.apiUrl + "/api/mark-token-used", {
+          await fetch(env.apiUrl + "/api/generation/mark-token-used", {
             method: "POST",
             headers,
             credentials: "include",
@@ -2495,7 +2495,7 @@ export default function Create() {
 
           // Get a pre-generated token
           const response = await fetch(
-            env.apiUrl + "/api/pre-generated-token",
+            env.apiUrl + "/api/generation/pre-generated-token",
             {
               method: "GET",
               headers,

--- a/packages/server/src/routes/generation.ts
+++ b/packages/server/src/routes/generation.ts
@@ -2233,6 +2233,7 @@ export async function generateAdditionalTokenImages(
 
 // Get a random pre-generated token endpoint
 app.get("/pre-generated-token", async (c) => {
+  console.log('Received request for /pre-generated-token'); // <--- Add this log
   try {
     const db = getDB();
 


### PR DESCRIPTION

## Fix: Correct Generation API Route Mounting and Client Calls

### Problem

The client-side code, primarily in `packages/client/src/pages/create.tsx`, was making API requests to generation-related endpoints using incorrect paths. For example, it was calling `/api/pre-generated-token` instead of the correct path `/api/generation/pre-generated-token`.

This discrepancy stemmed from how the `generationRouter` is mounted in the server setup (`packages/server/src/index.ts`):

```typescript
// packages/server/src/index.ts
// ...
const api = new Hono<{ Variables: AppVariables }>();
// ...
api.route("/generation", generationRouter); // Mounted with /generation prefix
// ...
app.route("/api", api); // Mounted with /api prefix
// ...
```

The client-side fetch calls were missing the crucial `/generation` segment required by the server routing configuration.

### Solution

This PR updates all relevant `fetch` calls within `packages/client/src/pages/create.tsx` to use the correct, full API paths, ensuring they include the `/api/generation/` prefix.

The following endpoints had their client-side call paths corrected:
*   `/api/generation/pre-generated-token`
*   `/api/generation/generate-metadata`
*   `/api/generation/generate`
*   `/api/generation/mark-token-used`

### Testing Corrected Endpoints with `curl`

You can manually test these corrected backend endpoints using `curl`.

**Note:** These endpoints require authentication. Replace `YOUR_AUTH_TOKEN_HERE` with a valid Bearer token obtained from your application's authentication flow.

---

#### Test `GET /api/generation/pre-generated-token`

Fetches a random, unused pre-generated token definition.

```bash
curl -X GET http://localhost:8787/api/generation/pre-generated-token \
     -H 'Authorization: Bearer YOUR_AUTH_TOKEN_HERE'
```
*   **Expected Success:** A JSON response with `success: true` and a `token` object.

---

#### Test `POST /api/generation/generate-metadata`

Generates token metadata (name, symbol, description, prompt) based on an input prompt.

```bash
curl -X POST http://localhost:8787/api/generation/generate-metadata \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Bearer YOUR_AUTH_TOKEN_HERE' \
     -d '{"prompt": "A cool cat wearing sunglasses", "fields": ["name", "symbol", "description", "prompt"]}'
```
*   **Expected Success:** A JSON response with `success: true` and a `metadata` object containing the generated fields.

---

#### Test `POST /api/generation/generate`

Generates media (defaults to an image) based on an input prompt.

```bash
curl -X POST http://localhost:8787/api/generation/generate \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Bearer YOUR_AUTH_TOKEN_HERE' \
     -d '{"prompt": "A photorealistic image of a cool cat wearing sunglasses"}'
```
*   **Expected Success:** A JSON response with `success: true`, a `mediaUrl` (pointing to the generated image), and rate limit info.

---

#### Test `POST /api/generation/mark-token-used`

Marks a specific pre-generated token (by its ID) as used and removes potential duplicates based on name/ticker.

**Note:** Replace `PRE_GENERATED_TOKEN_ID_HERE` with an actual ID obtained from the `GET /api/generation/pre-generated-token` call.

```bash
curl -X POST http://localhost:8787/api/generation/mark-token-used \
     -H 'Content-Type: application/json' \
     -H 'Authorization: Bearer YOUR_AUTH_TOKEN_HERE' \
     -d '{"id": "PRE_GENERATED_TOKEN_ID_HERE", "name": "OptionalNameForDuplicateCheck", "ticker": "OptionalTickerForDuplicateCheck"}'
```
*   **Expected Success:** A JSON response with `success: true` and a confirmation message.

---

These changes ensure the client correctly communicates with the server's generation endpoints, resolving the 404 errors previously encountered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal API endpoints used during creation flows; no changes to visible features or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->