### PR TITLE
fix: correct token value

### DIFF
--- a/packages/client/src/pages/token.tsx
+++ b/packages/client/src/pages/token.tsx
@@ -671,10 +671,10 @@ export default function Page() {
                     Value:
                   </span>
                   <span className="text-sm font-dm-mono text-autofun-text-secondary">
-                    {formatNumber(tokenBalance * currentPrice, false, true)} SOL
+                    {formatNumber(tokenBalance * priceSOL, false, true)} SOL
                     /{" "}
                     {formatNumber(
-                      tokenBalance * currentPrice * solanaPrice,
+                      tokenBalance * priceSOL * solanaPrice,
                       true,
                       false,
                     )}


### PR DESCRIPTION
related: https://linear.app/eliza-labs/issue/AUT-504/wrong-value-under-swap-button-106k-eli5-tokens-are-worth-more-than-013

result:

<img width="398" alt="Screenshot 2025-04-28 at 11 52 12 PM" src="https://github.com/user-attachments/assets/996415c3-9fab-4dd3-a8f9-833e0f1172c9" />
