### PR TITLE
fix: enhance chart y axis

### DIFF
--- a/packages/client/src/components/chart.tsx
+++ b/packages/client/src/components/chart.tsx
@@ -138,6 +138,9 @@ export default function Chart({ token }: ChartProps) {
       downColor: "rgb(225, 50, 85)",
       baseLineColor: "#212121",
       borderVisible: false,
+      priceFormat: {
+        minMove: 0.00000001,
+      },
     });
 
     candlestickSeriesRef.current = candlestickSeries;

--- a/packages/client/src/components/chart.tsx
+++ b/packages/client/src/components/chart.tsx
@@ -110,7 +110,11 @@ export default function Chart({ token }: ChartProps) {
       localization: {
         // priceFormatter: (price: number) => formatNumber(price, true, false),
         priceFormatter: (price: number) => {
-          const decimalsLength = String(price)?.split(".")?.[1];
+          // Force the price into standard decimal notation (no scientific notation), keeping up to 12 digits after the decimal
+          // Example: 3.5898363524445996e-8 → "0.000000035898"
+          const normal = Number(price).toFixed(12);
+          const decimalsLength = normal.split(".")[1]?.replace(/0+$/, "")?.length || 1;
+
           return new Intl.NumberFormat("en-US", {
             notation: "standard",
             style: "currency",

--- a/packages/client/src/components/chart.tsx
+++ b/packages/client/src/components/chart.tsx
@@ -113,7 +113,8 @@ export default function Chart({ token }: ChartProps) {
           // Force the price into standard decimal notation (no scientific notation), keeping up to 12 digits after the decimal
           // Example: 3.5898363524445996e-8 → "0.000000035898"
           const normal = Number(price).toFixed(12);
-          const decimalsLength = normal.split(".")[1]?.replace(/0+$/, "")?.length || 1;
+          const decimalsLength =
+            normal.split(".")[1]?.replace(/0+$/, "")?.length || 1;
 
           return new Intl.NumberFormat("en-US", {
             notation: "standard",


### PR DESCRIPTION
This pr fix few issues:

1. When rendering tokens with extremely low prices (e.g., 0.00000004), the chart was automatically scaling the Y-axis using large step sizes such as 0.01, 0.02, etc. This made the chart unreadable and misleading, as it failed to reflect the actual price range. related: https://linear.app/eliza-labs/issue/AUT-509/unbonded-chart-should-not-show-negative-values-in-y-axis

before:

<img width="956" alt="Screenshot 2025-04-29 at 5 03 19 PM" src="https://github.com/user-attachments/assets/05d4b68a-1630-4138-9ed0-3f0c9c7016a0" />


after:

<img width="944" alt="Screenshot 2025-04-29 at 5 03 41 PM" src="https://github.com/user-attachments/assets/c1720288-4c30-46c6-b6df-d27a14459adb" />


2. This PR also fixes an issue with the priceFormatter. Previously, when the input price was in scientific notation (e.g., 3.5898363524445996e-8), it was formatted incorrectly due to how .split(".") was applied on an exponential string.


before:

<img width="962" alt="Screenshot 2025-04-29 at 5 05 45 PM" src="https://github.com/user-attachments/assets/fadadf7c-6e5c-47b6-aa65-20031efd1ecf" />


after:

<img width="950" alt="Screenshot 2025-04-29 at 5 06 11 PM" src="https://github.com/user-attachments/assets/14392fef-a627-4578-9c22-1aec68bf5fb8" />



