### PR TITLE
fix: handle gaps in candles and periods of no trading

### DIFF
--- a/packages/client/src/components/chart.tsx
+++ b/packages/client/src/components/chart.tsx
@@ -33,7 +33,7 @@ export default function Chart({ token }: ChartProps) {
     queryKey: ["token", mint, "chart"],
     queryFn: async () => {
       const to = Math.floor(new Date().getTime() / 1000.0);
-      const from = to - 21600 * 2;
+      const from = 0;
 
       const data = await getChartTable({
         pairIndex: 10,
@@ -61,11 +61,13 @@ export default function Chart({ token }: ChartProps) {
 
       return data.table.filter(
         (candle) =>
+          !isNaN(Number(candle.volume)) &&
           !isNaN(Number(candle.open)) &&
           !isNaN(Number(candle.high)) &&
           !isNaN(Number(candle.low)) &&
           !isNaN(Number(candle.close)) &&
-          !isNaN(Number(candle.time)),
+          !isNaN(Number(candle.time)) &&
+          candle.volume > 0,
       );
     },
     staleTime: 60 * 1000,

--- a/packages/client/src/types/index.ts
+++ b/packages/client/src/types/index.ts
@@ -40,6 +40,7 @@ export type ChartTable = {
     low: number;
     close: number;
     time: number;
+    volume: number;
   }[];
 };
 


### PR DESCRIPTION
Some tokens were showing gaps in their chart data, especially when no trades were made for extended periods.

Solution:
- Set the `from` timestamp to 0 to fetch the full trading history when needed.

- Filtered out candles with invalid or zero volume to avoid gaps.

before: (https://auto.fun/token/EP2A5hZUczopQjQGQQSmKJyW4G2ChrcGCTbMrhmuaFUN)

<img width="1495" alt="Screenshot 2025-04-30 at 6 25 09 PM" src="https://github.com/user-attachments/assets/5b8ffc09-41e9-48bc-a431-fef0836e09a2" />

after:

https://github.com/user-attachments/assets/98ef79b9-5b27-4b2f-8f94-bb27b31e2524


