### PR TITLE
container width change

### DIFF
--- a/packages/client/src/layout/root.tsx
+++ b/packages/client/src/layout/root.tsx
@@ -44,7 +44,7 @@ export default function Layout() {
     <QueryClientProvider client={queryClient}>
       <Providers>
         <div className="min-h-screen bg-autofun-background-primary text-autofun-text-primary flex flex-col font-satoshi antialiased items-center">
-          <div className="max-w-[1440px]">
+          <div className="mx-0 lg:mx-[6vh] xl:mx-[8vh] 2xl:mx-[12vh]">
             {isTosAccepted ? <Header /> : null}
             <main className="flex-grow px-2 md:px-4">
               <Outlet />


### PR DESCRIPTION
We are missing out on a lot of real estate for people visiting the site on a monitor(I am on a 27 inch)
This makes sure the padding is relatively equals on all screens

before:
<img width="1269" alt="Screenshot 2025-05-09 at 09 26 50" src="https://github.com/user-attachments/assets/7d44ff31-3088-433e-ab87-ba92d59f780f" />
